### PR TITLE
[ compat ] adjust to changes in elab-util

### DIFF
--- a/.github/workflows/ci-lib.yml
+++ b/.github/workflows/ci-lib.yml
@@ -14,8 +14,8 @@ on:
 env:
   IDRIS2_COMMIT: v0.6.0
   SCHEME: scheme
-  ELAB_COMMIT: 99babcbf4deeeca283ba62a64b3ce243bd690fcb
-  SOP_COMMIT: 2389da58fb453ecabed7acf0c5c0b4d723ad2d2f
+  ELAB_COMMIT: 87f9d910f4669b38d9d2cd67b5a63922dffb1ab1
+  SOP_COMMIT: 87a30cf81117f387824f945374081ffa2effa8a0
 
 jobs:
   ubuntu-chez:

--- a/.github/workflows/ci-lib.yml
+++ b/.github/workflows/ci-lib.yml
@@ -26,11 +26,11 @@ jobs:
       fail-fast: false
     container: ghcr.io/stefan-hoeck/idris2-pack:latest
     steps:
-      - name: Install idris2-sop
-        run: pack install sop
-
       - name: Checkout idris2-tls
         uses: actions/checkout@v2
+
+      - name: Install idris2-sop
+        run: pack install sop
 
       - name: Build package
         run: make install

--- a/pack.toml
+++ b/pack.toml
@@ -1,0 +1,11 @@
+[custom.all.elab-util]
+type   = "git"
+url    = "https://github.com/stefan-hoeck/idris2-elab-util"
+commit = "latest:main"
+ipkg   = "elab-util.ipkg"
+
+[custom.all.sop]
+type   = "git"
+url    = "https://github.com/stefan-hoeck/idris2-sop"
+commit = "latest:main"
+ipkg   = "sop.ipkg"

--- a/src/Network/TLS/Certificate.idr
+++ b/src/Network/TLS/Certificate.idr
@@ -14,7 +14,12 @@ import Data.String.Parser
 import Data.String.Extra
 import Crypto.Hash
 import Decidable.Equality
+import Derive.Prelude
 import Generics.Derive
+
+%hide Generics.Derive.Eq
+%hide Generics.Derive.Ord
+%hide Generics.Derive.Show
 
 %language ElabReflection
 

--- a/src/Network/TLS/Magic.idr
+++ b/src/Network/TLS/Magic.idr
@@ -9,7 +9,12 @@ import Crypto.Hash
 import Crypto.ECDH
 import Crypto.Curve
 import Crypto.Curve.Weierstrass
+import Derive.Prelude
 import Generics.Derive
+
+%hide Generics.Derive.Eq
+%hide Generics.Derive.Ord
+%hide Generics.Derive.Show
 
 %language ElabReflection
 

--- a/src/Utils/Time.idr
+++ b/src/Utils/Time.idr
@@ -8,7 +8,12 @@ import Data.String
 import Data.Fin.Extra
 import Utils.Misc
 import Decidable.Equality
+import Derive.Prelude
 import Generics.Derive
+
+%hide Generics.Derive.Eq
+%hide Generics.Derive.Ord
+%hide Generics.Derive.Show
 
 %language ElabReflection
 


### PR DESCRIPTION
As I wrote on discord, I'm in the process of refactoring elab-util. Those changes will introduce deprecation warnings to this library, and this PR fixes that. Please note, that elab-util does not support deriving of `DecEq`, because that's indeed *a lot* easier to get right by going via SOPs.

Anyway, I'm still busy fixing those libraries in the pack collection, which will break with the elab-util update, so please don't merge this yet. I'll drop you a note, once I merged elab-util.
